### PR TITLE
baseURL processor for dash parser

### DIFF
--- a/packages/web-media-box/src/dash-parser/parse.ts
+++ b/packages/web-media-box/src/dash-parser/parse.ts
@@ -18,9 +18,17 @@ import {
   SEGMENT_TEMPLATE,
   // EVENT_STREAM,
   // EVENT,
-  // BASE_URL,
+  BASE_URL,
 } from '@/dash-parser/consts/tags.ts';
-import { AdaptationSet, Mpd, Period, Representation, UTCTiming, SegmentTemplate } from '@/dash-parser/tags/base.ts';
+import {
+  AdaptationSet,
+  Mpd,
+  Period,
+  Representation,
+  UTCTiming,
+  SegmentTemplate,
+  BaseUrl,
+} from '@/dash-parser/tags/base.ts';
 import type { TagInfo } from '@/dash-parser/stateMachine.ts';
 import { ignoreTagWarn, unsupportedTagWarn } from '@/dash-parser/utils/warn.ts';
 import createStateMachine from '@/dash-parser/stateMachine.ts';
@@ -59,9 +67,18 @@ class Parser {
     this.parsedManifest = structuredClone(defaultParsedManifest);
 
     this.sharedState = {
+      baseUrls: [],
       mpdAttributes: {},
       adaptationSetAttributes: {},
     };
+
+    // If the manifest URI is inteded to be used as the initial baseURL, set it here
+    if (options.uri) {
+      this.sharedState.baseUrls.push({
+        uri: options.uri,
+        attributes: {},
+      });
+    }
 
     this.pendingProcessors = new PendingProcessors();
 
@@ -72,6 +89,7 @@ class Parser {
       [REPRESENTATION]: new Representation(this.warnCallback),
       [UTC_TIMING]: new UTCTiming(this.warnCallback),
       [SEGMENT_TEMPLATE]: new SegmentTemplate(this.warnCallback),
+      [BASE_URL]: new BaseUrl(this.warnCallback),
     };
   }
 

--- a/packages/web-media-box/src/dash-parser/segments/resolveUrl.ts
+++ b/packages/web-media-box/src/dash-parser/segments/resolveUrl.ts
@@ -1,0 +1,41 @@
+const DEFAULT_LOCATION = 'http://example.com';
+
+export const resolveURL = (relativeUrl: string, baseUrl: string): string => {
+  // return early if have an absolute url
+  if (/^[a-z]+:/i.test(relativeUrl)) {
+    return relativeUrl;
+  } // if baseUrl is a data URI, ignore it and resolve everything relative to window.location
+
+  if (/^data:/.test(baseUrl)) {
+    baseUrl = (window.location && window.location.href) || '';
+  } // IE11 supports URL but not the URL constructor
+  // feature detect the behavior we want
+
+  const nativeURL = typeof window.URL === 'function';
+  const protocolLess = /^\/\//.test(baseUrl); // remove location if window.location isn't available (i.e. we're in node)
+  // and if baseUrl isn't an absolute url
+
+  const removeLocation = !window.location && !/\/\//i.test(baseUrl); // if the base URL is relative then combine with the current location
+
+  if (nativeURL) {
+    baseUrl = new window.URL(baseUrl, window.location.href || DEFAULT_LOCATION).href;
+  } else if (!/\/\//i.test(baseUrl)) {
+    baseUrl = new URL((window.location && window.location.href) || '', baseUrl).href;
+  }
+
+  if (nativeURL) {
+    const newUrl = new URL(relativeUrl, baseUrl); // if we're a protocol-less url, remove the protocol
+    // and if we're location-less, remove the location
+    // otherwise, return the url unmodified
+
+    if (removeLocation) {
+      return newUrl.href.slice(DEFAULT_LOCATION.length);
+    } else if (protocolLess) {
+      return newUrl.href.slice(newUrl.protocol.length);
+    }
+
+    return newUrl.href;
+  }
+
+  return new URL(baseUrl, relativeUrl).href;
+};

--- a/packages/web-media-box/src/dash-parser/segments/segmentParser.ts
+++ b/packages/web-media-box/src/dash-parser/segments/segmentParser.ts
@@ -1,17 +1,7 @@
 import type { Segment } from '../types/parsedManifest';
+import { resolveURL } from './resolveUrl';
 
 const identifierPattern = /\$([A-z]*)(?:(%0)([0-9]+)d)?\$/g;
-
-/**
- * TODO: Implement correctly for BaseURL
- */
-export const resolveURL = (relativeUrl: string, baseUrl: string): string => {
-  try {
-    return new URL(relativeUrl, baseUrl).href;
-  } catch {
-    return relativeUrl || '';
-  }
-};
 
 /**
  * Returns a function to be used as a callback for String.prototype.replace to replace
@@ -294,7 +284,7 @@ export const segmentsFromTemplate = (mpdType: string, attributes: Record<string,
       duration: segment.duration as number,
       segmentNumber: segment.segmentNumber as number,
       uri,
-      resolvedUri: uri,
+      resolvedUri: resolveURL(uri, (attributes.baseUrl as string) || ''),
       presentationTime,
       timeline: segment.timeline as number,
     };

--- a/packages/web-media-box/src/dash-parser/types/sharedState.d.ts
+++ b/packages/web-media-box/src/dash-parser/types/sharedState.d.ts
@@ -1,7 +1,14 @@
 export interface SharedState {
+  baseUrls: Array<BaseURLState>;
   mpdAttributes: Record<string, unknown>;
   periodAttributes?: Record<string, unknown>;
   adaptationSetAttributes?: Record<string, unknown>;
   segmentTemplateAttributes?: Record<string, unknown>;
   attributes?: Record<string, unknown>;
+}
+
+interface BaseURLState {
+  uri: string;
+  attributes: Record<string, unknown>;
+  parentKey?: string | null;
 }

--- a/packages/web-media-box/test/dash-parser/examples/mpd.ts
+++ b/packages/web-media-box/test/dash-parser/examples/mpd.ts
@@ -1,7 +1,10 @@
 export const testMPD = `<MPD mediaPresentationDuration="PT634.566S" minBufferTime="PT2.00S" profiles="urn:hbbtv:dash:profile:isoff-live:2012,urn:mpeg:dash:profile:isoff-live:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd">
-<BaseURL>./</BaseURL>
+<BaseURL>https://www.example.com/</BaseURL>
+<BaseURL>https://www.example234.com/</BaseURL>
 <Period>
+ <BaseURL>additionalPath1/</BaseURL>
  <AdaptationSet mimeType="video/mp4" contentType="video" subsegmentAlignment="true" subsegmentStartsWithSAP="1" par="16:9">
+  <BaseURL>additionalPath2/</BaseURL> 
   <SegmentTemplate duration="120" timescale="30" media="$RepresentationID$/$RepresentationID$_$Number$.m4v" startNumber="1" initialization="$RepresentationID$/$RepresentationID$_0.m4v"/>
   <Representation id="bbb_30fps_1024x576_2500k" codecs="avc1.64001f" bandwidth="3134488" width="1024" height="576" frameRate="30" sar="1:1" scanType="progressive"/>
   <Representation id="bbb_30fps_1280x720_4000k" codecs="avc1.64001f" bandwidth="4952892" width="1280" height="720" frameRate="30" sar="1:1" scanType="progressive"/>


### PR DESCRIPTION
Functionality for BaseURL processing. Note:

- This still does not handle `BaseURL` tags that are children of `Representation`. That will come in future changes.

To test: 
Change the current test in dash-parser to use
`expect(parsed.representations[0]).toBe('static');`

View the errors in the console, and see that the `resolvedUri` propertiy on the segments now correctly uses the BaseURL values from the MPD.