### PR TITLE
feat: hls-parser from service locator

### DIFF
--- a/packages/playback/.size-limit.json
+++ b/packages/playback/.size-limit.json
@@ -1,26 +1,26 @@
 [
   {
     "path": "dist/player/core/cjs/index.min.js",
-    "limit": "1 s"
+    "limit": "800 ms"
   },
   {
     "path": "dist/player/core/es/index.min.js",
-    "limit": "1 s"
+    "limit": "800 ms"
   },
   {
     "path": "dist/player/core/iife/index.min.js",
-    "limit": "1 s"
+    "limit": "800 ms"
   },
   {
     "path": "dist/player-with-worker/core/cjs/index.min.js",
-    "limit": "1 s"
+    "limit": "800 ms"
   },
   {
     "path": "dist/player-with-worker/core/es/index.min.js",
-    "limit": "1 s"
+    "limit": "800 ms"
   },
   {
     "path": "dist/player-with-worker/core/iife/index.min.js",
-    "limit": "1 s"
+    "limit": "800 ms"
   }
 ]

--- a/packages/playback/src/lib/pipeline-loaders/hls-pipeline-loader.ts
+++ b/packages/playback/src/lib/pipeline-loaders/hls-pipeline-loader.ts
@@ -1,5 +1,4 @@
 import type { ChunkPlaylistParser } from '@videojs/hls-parser';
-
 import type { IPipeline, IPipelineLoader, IPipelineLoaderDependencies } from '../types/pipeline.declarations';
 import type { INetworkManager, INetworkRequest } from '../types/network.declarations';
 import type { ILogger } from '../types/logger.declarations';
@@ -16,6 +15,10 @@ export class HlsPipelineLoader implements IPipelineLoader {
 
   public static setHlsParser(parser: typeof ChunkPlaylistParser): void {
     HlsPipelineLoader.hlsParserFactory_ = parser;
+  }
+
+  public static getHlsParser(): typeof ChunkPlaylistParser | null {
+    return HlsPipelineLoader.hlsParserFactory_;
   }
 
   public static setVodPipelineFactory(): void {}

--- a/packages/playback/src/lib/pipeline-loaders/hls-pipeline-loader.ts
+++ b/packages/playback/src/lib/pipeline-loaders/hls-pipeline-loader.ts
@@ -13,11 +13,11 @@ interface IHlsPipelineLoaderDependencies extends IPipelineLoaderDependencies {
 export class HlsPipelineLoader implements IPipelineLoader {
   private static hlsParserFactory_: typeof ChunkPlaylistParser | null = null;
 
-  public static setHlsParser(parser: typeof ChunkPlaylistParser): void {
+  public static setHlsParserFactory(parser: typeof ChunkPlaylistParser): void {
     HlsPipelineLoader.hlsParserFactory_ = parser;
   }
 
-  public static getHlsParser(): typeof ChunkPlaylistParser | null {
+  public static getHlsParserFactory(): typeof ChunkPlaylistParser | null {
     return HlsPipelineLoader.hlsParserFactory_;
   }
 

--- a/packages/playback/src/lib/service-locator.ts
+++ b/packages/playback/src/lib/service-locator.ts
@@ -18,8 +18,6 @@ import { EventEmitter } from './utils/event-emitter';
 import { NetworkManager } from './network/network-manager';
 import { PlayerEventType } from './consts/events';
 import { PipelineLoaderFactoryStorage } from './utils/pipeline-loader-factory-storage';
-import type { ChunkPlaylistParser } from '@videojs/hls-parser';
-import { HlsPipelineLoader } from './pipeline-loaders/hls-pipeline-loader';
 
 export class ServiceLocator {
   public readonly logger: ILogger;
@@ -67,9 +65,5 @@ export class ServiceLocator {
 
   protected createNetworkManager_(dependencies: NetworkManagerDependencies): INetworkManager {
     return new NetworkManager(dependencies);
-  }
-
-  public getHlsParser(): typeof ChunkPlaylistParser | null {
-    return HlsPipelineLoader.getHlsParser();
   }
 }

--- a/packages/playback/src/lib/service-locator.ts
+++ b/packages/playback/src/lib/service-locator.ts
@@ -18,6 +18,8 @@ import { EventEmitter } from './utils/event-emitter';
 import { NetworkManager } from './network/network-manager';
 import { PlayerEventType } from './consts/events';
 import { PipelineLoaderFactoryStorage } from './utils/pipeline-loader-factory-storage';
+import type { ChunkPlaylistParser } from '@videojs/hls-parser';
+import { HlsPipelineLoader } from './pipeline-loaders/hls-pipeline-loader';
 
 export class ServiceLocator {
   public readonly logger: ILogger;
@@ -65,5 +67,9 @@ export class ServiceLocator {
 
   protected createNetworkManager_(dependencies: NetworkManagerDependencies): INetworkManager {
     return new NetworkManager(dependencies);
+  }
+
+  public getHlsParser(): typeof ChunkPlaylistParser | null {
+    return HlsPipelineLoader.getHlsParser();
   }
 }

--- a/packages/playback/test/lib/pipeline-loaders/hls-pipeline-loader.test.ts
+++ b/packages/playback/test/lib/pipeline-loaders/hls-pipeline-loader.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { HlsPipelineLoader } from '../../../src/lib/pipeline-loaders/hls-pipeline-loader';
+import { ChunkPlaylistParser } from '@videojs/hls-parser';
+
+describe('hls-pipeline-loader spec', () => {
+  it('parser is static pipeline loader member', () => {
+    expect(HlsPipelineLoader.getHlsParser()).toBe(null);
+    // set parser
+    HlsPipelineLoader.setHlsParser(ChunkPlaylistParser);
+    const ChunkHlsParser = HlsPipelineLoader.getHlsParser();
+    expect(ChunkHlsParser).toBeTypeOf('function');
+    const parser = ChunkHlsParser ? ChunkHlsParser.create({}) : null;
+    expect(parser).toBeInstanceOf(ChunkPlaylistParser);
+  });
+});

--- a/packages/playback/test/lib/pipeline-loaders/hls-pipeline-loader.test.ts
+++ b/packages/playback/test/lib/pipeline-loaders/hls-pipeline-loader.test.ts
@@ -4,10 +4,10 @@ import { ChunkPlaylistParser } from '@videojs/hls-parser';
 
 describe('hls-pipeline-loader spec', () => {
   it('parser is static pipeline loader member', () => {
-    expect(HlsPipelineLoader.getHlsParser()).toBe(null);
+    expect(HlsPipelineLoader.getHlsParserFactory()).toBe(null);
     // set parser
-    HlsPipelineLoader.setHlsParser(ChunkPlaylistParser);
-    const ChunkHlsParser = HlsPipelineLoader.getHlsParser();
+    HlsPipelineLoader.setHlsParserFactory(ChunkPlaylistParser);
+    const ChunkHlsParser = HlsPipelineLoader.getHlsParserFactory();
     expect(ChunkHlsParser).toBeTypeOf('function');
     const parser = ChunkHlsParser ? ChunkHlsParser.create({}) : null;
     expect(parser).toBeInstanceOf(ChunkPlaylistParser);

--- a/packages/playback/test/lib/service-locator.test.ts
+++ b/packages/playback/test/lib/service-locator.test.ts
@@ -1,7 +1,5 @@
-import { ChunkPlaylistParser } from '@videojs/hls-parser';
 import { ServiceLocator } from '../../src/lib/service-locator';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { HlsPipelineLoader } from '../../src/lib/pipeline-loaders/hls-pipeline-loader';
 
 describe('Service locator spec', () => {
   let serviceLocator: ServiceLocator;
@@ -11,15 +9,5 @@ describe('Service locator spec', () => {
 
   it('should create a service locator instance', () => {
     expect(serviceLocator).toBeInstanceOf(ServiceLocator);
-  });
-
-  it('should return the chunk hls parser', () => {
-    expect(serviceLocator.getHlsParser()).toEqual(null);
-    // set parser
-    HlsPipelineLoader.setHlsParser(ChunkPlaylistParser);
-    const ChunkHlsParser = serviceLocator.getHlsParser();
-    expect(ChunkHlsParser).toBeTypeOf('function');
-    const parser = ChunkHlsParser ? ChunkHlsParser.create({}) : null;
-    expect(parser).toBeInstanceOf(ChunkPlaylistParser);
   });
 });

--- a/packages/playback/test/lib/service-locator.test.ts
+++ b/packages/playback/test/lib/service-locator.test.ts
@@ -1,0 +1,25 @@
+import { ChunkPlaylistParser } from '@videojs/hls-parser';
+import { ServiceLocator } from '../../src/lib/service-locator';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { HlsPipelineLoader } from '../../src/lib/pipeline-loaders/hls-pipeline-loader';
+
+describe('Service locator spec', () => {
+  let serviceLocator: ServiceLocator;
+  beforeEach(() => {
+    serviceLocator = new ServiceLocator();
+  });
+
+  it('should create a service locator instance', () => {
+    expect(serviceLocator).toBeInstanceOf(ServiceLocator);
+  });
+
+  it('should return the chunk hls parser', () => {
+    expect(serviceLocator.getHlsParser()).toEqual(null);
+    // set parser
+    HlsPipelineLoader.setHlsParser(ChunkPlaylistParser);
+    const ChunkHlsParser = serviceLocator.getHlsParser();
+    expect(ChunkHlsParser).toBeTypeOf('function');
+    const parser = ChunkHlsParser ? ChunkHlsParser.create({}) : null;
+    expect(parser).toBeInstanceOf(ChunkPlaylistParser);
+  });
+});


### PR DESCRIPTION
## Description
- add `getHlsParser` functionality to the service locator.
- add basic service locator tests

## Specific Changes proposed
expose the full HLS parser through the a `getHlsParser` function and add tests.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Change has been verified in an actual browser (Chrome, Firefox, Safari, Edge) (if applicable)
- [x] Unit Tests updated or fixed (if applicable)
- [ ] Docs/guides updated (if applicable)
